### PR TITLE
✨ Add `-v`/`-version` command-line argument

### DIFF
--- a/src/main/java/edu/wisc/cs/will/Boosting/Utils/CommandLineArguments.java
+++ b/src/main/java/edu/wisc/cs/will/Boosting/Utils/CommandLineArguments.java
@@ -23,6 +23,8 @@ public class CommandLineArguments {
 	 * 5. Define a usage string in getUsageString
 	 */
 
+	public static final String srlboost_version = "0.1.1";
+
 	private static final String argPrefix = "-";
 	private static final String learn = "l";
 
@@ -164,6 +166,11 @@ public class CommandLineArguments {
 
 			if (args[i].trim().isEmpty())
 				continue;
+
+			if (argMatches(args[i], "v") || argMatches(args[i], "version")) {
+				System.out.println(srlboost_version);
+				System.exit(0);
+			}
 
 			if (argMatches(args[i], "h") || argMatches(args[i], "help")) {
 				System.out.println(getUsageString());


### PR DESCRIPTION
Currently this sets the `SRLBoost` version to `0.1.1` for further
development beyond the `0.1.0` tag.