### PR TITLE
🔧 Bump `version = '0.1.1'` in `build.gradle`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 }
 
 group = 'edu.wisc.cs.will'
-version = '0.1.0'
+version = '0.1.1'
 description = 'SRLBoost'
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 


### PR DESCRIPTION
Missed this in the previous commit. There might be a sanity check
such that we test whether the version number checked into the
code is the same as the version in the gradle build.