### PR TITLE
🔥 Drop support for renaming `pos` / `neg` / `facts`

### DIFF
--- a/src/main/java/edu/wisc/cs/will/Boosting/RDN/WILLSetup.java
+++ b/src/main/java/edu/wisc/cs/will/Boosting/RDN/WILLSetup.java
@@ -95,9 +95,9 @@ public final class WILLSetup {
 
 		String[] file_paths = new String[4];
 
-		file_paths[0] = directory + "/" + prefix + "_" + cmdArgs.getStringForTestsetPos()   + Utils.defaultFileExtensionWithPeriod;
-		file_paths[1] = directory + "/" + prefix + "_" + cmdArgs.getStringForTestsetNeg()   + Utils.defaultFileExtensionWithPeriod;
-		file_paths[3] = directory + "/" + prefix + "_" + cmdArgs.getStringForTestsetFacts() + Utils.defaultFileExtensionWithPeriod;
+		file_paths[0] = directory + "/" + prefix + "_pos"   + Utils.defaultFileExtensionWithPeriod;
+		file_paths[1] = directory + "/" + prefix + "_neg"   + Utils.defaultFileExtensionWithPeriod;
+		file_paths[3] = directory + "/" + prefix + "_facts" + Utils.defaultFileExtensionWithPeriod;
 		file_paths[2] = directory + "/" + prefix + "_bk"                                    + Utils.defaultFileExtensionWithPeriod;
 
 		String appendToPrefix="";

--- a/src/main/java/edu/wisc/cs/will/Boosting/Utils/CommandLineArguments.java
+++ b/src/main/java/edu/wisc/cs/will/Boosting/Utils/CommandLineArguments.java
@@ -128,12 +128,6 @@ public class CommandLineArguments {
 
 	private static final String testNegsToPosRatio = "testNegPosRatio";
 	private double testNegsToPosRatioVal = -1;
-	private static final String testPosString      = "testPosString"; // Allow overriding of the default.
-	private String stringForTestsetPos = "pos";
-	private static final String testNegString      = "testNegString"; // Allow overriding of the default.
-	private String stringForTestsetNeg  = "neg";
-	private static final String testFactsString    = "testFactsString"; // Allow overriding of the default.
-	private String stringForTestsetFacts = "facts";
 
 	private static final String aucPath = "aucJarPath";
 	private String aucPathVal = null;
@@ -356,18 +350,6 @@ public class CommandLineArguments {
 				testNegsToPosRatioVal=Double.parseDouble(args[++i]);
 				continue;
 			}
-			if (argMatches(args[i], testPosString)) {
-				stringForTestsetPos = args[++i];
-				continue;
-			}
-			if (argMatches(args[i], testNegString)) {
-				stringForTestsetNeg = args[++i];
-				continue;
-			}
-			if (argMatches(args[i], testFactsString)) {
-				stringForTestsetFacts = args[++i];
-				continue;
-			}
 			if (argMatches(args[i], samplePosProb)) {
 				samplePosProbVal=Double.parseDouble(args[++i]);
 				continue;
@@ -587,16 +569,12 @@ public class CommandLineArguments {
 		return testNegsToPosRatioVal;
 	}
 
-	public String getStringForTestsetPos() {
-		return stringForTestsetPos;
-	}
-
 	public String getExtraMarkerForFiles(boolean includeTestSkew) {
 		// TODO(@hayesall): Factor out the need for the file system.
 		String result = "_";
-		if (stringForTestsetPos != null)            { result += stringForTestsetPos + "_"; }
-		if (stringForTestsetNeg != null)            { result += stringForTestsetNeg + "_"; }
-		 result += getAnyStringForModEquals();
+		result += "pos_";
+		result += "neg_";
+		result += getAnyStringForModEquals();
 		if (maxLiteralsInAnInteriorNodeVal >= 0)    { result += "Lits"  + maxLiteralsInAnInteriorNodeVal; }
 		if (maxTreesVal                    >= 0)    { result += "Trees" + maxTreesVal; }
 		if (sampleNegsToPosRatioVal        >= 0)    { result += "Skew"     + (int) sampleNegsToPosRatioVal; }
@@ -607,14 +585,6 @@ public class CommandLineArguments {
 
 	public int getMaxLiteralsInAnInteriorNode() {
 		return maxLiteralsInAnInteriorNodeVal;
-	}
-
-	public String getStringForTestsetNeg() {
-		return stringForTestsetNeg;
-	}
-	
-	public String getStringForTestsetFacts() {
-		return stringForTestsetFacts;
 	}
 
 	public boolean isJointModelDisabled() {

--- a/src/main/java/edu/wisc/cs/will/Boosting/Utils/CommandLineArguments.java
+++ b/src/main/java/edu/wisc/cs/will/Boosting/Utils/CommandLineArguments.java
@@ -558,7 +558,6 @@ public class CommandLineArguments {
 		String result = "_";
 		result += "pos_";
 		result += "neg_";
-		result += getAnyStringForModEquals();
 		if (maxLiteralsInAnInteriorNodeVal >= 0)    { result += "Lits"  + maxLiteralsInAnInteriorNodeVal; }
 		if (maxTreesVal                    >= 0)    { result += "Trees" + maxTreesVal; }
 		if (sampleNegsToPosRatioVal        >= 0)    { result += "Skew"     + (int) sampleNegsToPosRatioVal; }


### PR DESCRIPTION
Specifically, this drops three CLI arguments from `main`:

- `-testPosString`
- `-testNegString`
- `-testFactsString`

which allowed overwriting whether later steps would look in
files other than `_pos.txt`, etc.