### PR TITLE
🔥 Drop references to `spy()` and `trace`

### DIFF
--- a/src/main/java/edu/wisc/cs/will/FOPC/HandleFOPCstrings.java
+++ b/src/main/java/edu/wisc/cs/will/FOPC/HandleFOPCstrings.java
@@ -108,9 +108,7 @@ public final class HandleFOPCstrings {
 
     public boolean underscoredAnonymousVariables = false;
 
-    public final PredicateNameAndArityFilter spyEntries = new PredicateNameAndArityFilter(this);
-
-    /* Clausebase handling for facts added to the clausebase. */
+	/* Clausebase handling for facts added to the clausebase. */
     public VariantClauseAction variantFactHandling = WARN_AND_REMOVE_VARIANTS;
 
     /* Clausebase handling for facts added to the clausebase. */
@@ -1457,11 +1455,6 @@ public final class HandleFOPCstrings {
     private String cleanString(String str, boolean hadQuotesOriginally) {
     	return Utils.cleanString(str, this, hadQuotesOriginally);
     }
-
-    public PredicateNameAndArityFilter getSpyEntries() {
-        return spyEntries;
-    }
-
 
 	StringConstant getAlphabeticalVariableName(int variableIndex) {
         StringBuilder stringBuilder = new StringBuilder();

--- a/src/main/java/edu/wisc/cs/will/FOPC/PredicateNameAndArityFilter.java
+++ b/src/main/java/edu/wisc/cs/will/FOPC/PredicateNameAndArityFilter.java
@@ -44,10 +44,6 @@ public class PredicateNameAndArityFilter implements Filter<PredicateNameAndArity
         addArityFilterEntry(predicateNameArity.getPredicateName(), predicateNameArity.getArity());
     }
 
-    public void removeLiteral(PredicateNameAndArity predicateNameArity) {
-        removeArityFilterEntry(predicateNameArity.getPredicateName(), predicateNameArity.getArity());
-    }
-
     public void clear() {
         nameToArityMap = null;
     }
@@ -69,24 +65,6 @@ public class PredicateNameAndArityFilter implements Filter<PredicateNameAndArity
         }
         else {
             arityFilter.addArity(arity);
-        }
-    }
-
-    private void removeArityFilterEntry(PredicateName predicateName, int arity) {
-        if (nameToArityMap != null) {
-            ArityFilter arityFilter = nameToArityMap.get(predicateName);
-            if (arityFilter != null) {
-                if (arity == -1) {
-                    arityFilter.setIncludeAllArities(false);
-                }
-                else {
-                    arityFilter.removeArity(arity);
-                }
-            }
-            assert arityFilter != null;
-            if (arityFilter.isEmpty()) {
-                nameToArityMap.remove(predicateName);
-            }
         }
     }
 

--- a/src/main/java/edu/wisc/cs/will/FOPC/StandardPredicateNames.java
+++ b/src/main/java/edu/wisc/cs/will/FOPC/StandardPredicateNames.java
@@ -64,8 +64,6 @@ public class StandardPredicateNames { // A few FUNCTION names also appear here; 
 
     public final FunctionName negationByFailureAsFunction;
 
-    public final PredicateName spy;
-
     public final PredicateName consCell;
 
     public final PredicateName equal;
@@ -137,8 +135,6 @@ public class StandardPredicateNames { // A few FUNCTION names also appear here; 
         FunctionName notEqualNumbersFunction = stringHandler.getFunctionName("=\\="); // Not equal numbers.
         FunctionName equalDotDotFunction = stringHandler.getFunctionName("=..");
 
-        spy = stringHandler.getPredicateName("spy");
-
         consCell = stringHandler.getPredicateName("consCell");
 
 
@@ -184,8 +180,6 @@ public class StandardPredicateNames { // A few FUNCTION names also appear here; 
         buildinPredicates.add(countUniqueBindings);
         buildinPredicates.add(then);
         buildinPredicates.add(negationByFailure);
-
-        buildinPredicates.add(spy);
 
         stringHandler.cleanFunctionAndPredicateNames = hold;
     }

--- a/src/main/java/edu/wisc/cs/will/ILP/LearnOneClause.java
+++ b/src/main/java/edu/wisc/cs/will/ILP/LearnOneClause.java
@@ -911,11 +911,6 @@ public class LearnOneClause extends StateBasedSearchTask {
                 return true;
             }
             else {
-
-                if ( prover.getTraceLevel() == 0 && prover.getSpyEntries().includeElement(head.predicateName, head.numberArgs())) {
-                    Utils.println("Spy point encountered on " + head.predicateName + "/" + head.numberArgs() + ".  Enabling tracing.");
-                    prover.setTraceLevel(1);
-                }
                 List<Literal> query = bindingList.applyTheta(clauseBody);
 				return prove(query);
 			}

--- a/src/main/java/edu/wisc/cs/will/ResThmProver/InitHornProofSpace.java
+++ b/src/main/java/edu/wisc/cs/will/ResThmProver/InitHornProofSpace.java
@@ -45,14 +45,7 @@ public class InitHornProofSpace extends Initializer {
         
         if ( openList != null ) initializeOpen(openList, nodes);
 
-        if ( getHornClauseProver().getTraceLevel() > 0 ) {
-            Utils.println(String.format("[%6d] Initial proof nodes:", proofCount));
-
-            for (HornSearchNode node : nodes) {
-                System.out.println(String.format("             [%d] %s", node.parentExpansionIndex, node.clause));
-            }
-        }
-	}
+    }
 
     private HornSearchNode[] createNonCutNodes(List<Literal> negatedQueryLiterals, long proofCount) {
         Clause negatedQuery = getStringHandler().getClause(negatedQueryLiterals, false); // These are all negated (i.e., checked above), so tell Clause() that.


### PR DESCRIPTION
This needs more extensive testing. My local test runs usually were
taking around 15 seconds for a complete build and test. After these
changes it consistently takes around 10 seconds.

There may have been a bug where spy points and traces were
set everywhere, causing memory to be consumed without end.

*Or* looping over every predicate to check whether it was a spy/trace
point may have taken time linear in the number of predicates.